### PR TITLE
Support more url schemes for getting standalone manifest

### DIFF
--- a/fetch.py
+++ b/fetch.py
@@ -17,6 +17,8 @@
 import subprocess
 import sys
 from urllib.parse import urlparse
+from urllib.request import urlopen
+
 
 def fetch_file(url):
   """Fetch a file from the specified source using the appropriate protocol.
@@ -35,7 +37,5 @@ def fetch_file(url):
       print('fatal: error running "gsutil": %s' % e.output,
             file=sys.stderr)
     sys.exit(1)
-  if scheme == 'file':
-    with open(url[len('file://'):], 'rb') as f:
-      return f.read()
-  raise ValueError('unsupported url %s' % url)
+  with urlopen(url) as f:
+    return f.read()


### PR DESCRIPTION
urllib.requests.urlopen also supports file, so call it unless the
scheme is 'gs'.  This adds http, https, and ftp support.