### PR TITLE
Ability to show root dir

### DIFF
--- a/subcmds/root.py
+++ b/subcmds/root.py
@@ -1,0 +1,6 @@
+from command import Command
+
+
+class Root(Command):
+    def Execute(self, opt, args):
+        print(self.manifest.topdir)


### PR DESCRIPTION
Test Plan

- did `repo init`
- checked I can do `./repo root`
```
chrisbernard@chrisbernard-mbp git-repo % ./repo root                                 
/Users/chrisbernard/git-repo
```